### PR TITLE
0.9.8.1 commit

### DIFF
--- a/Master/NucleusCoopTool/Forms/MainForm.cs
+++ b/Master/NucleusCoopTool/Forms/MainForm.cs
@@ -24,7 +24,7 @@ namespace Nucleus.Coop
     /// </summary>
     public partial class MainForm : BaseForm
     {
-        public string version = "v0.9.8.0 ALPHA";
+        public string version = "v0.9.8.1 ALPHA";
 
         private Settings settingsForm = null;
 

--- a/Master/NucleusGaming/Platform/IO/WinDirectoryUtil.cs
+++ b/Master/NucleusGaming/Platform/IO/WinDirectoryUtil.cs
@@ -27,7 +27,7 @@ namespace Nucleus.Gaming.Platform.Windows.IO
                     for (int j = 0; j < exclusions.Length; j++)
                     {
                         string exc = exclusions[j];
-                        if (!string.IsNullOrEmpty(exc) && lower.Equals(exc))
+                        if (!string.IsNullOrEmpty(exc) && lower.Contains(exc))
                         {
                             // check if the file is i
                             exclude = true;
@@ -46,7 +46,7 @@ namespace Nucleus.Gaming.Platform.Windows.IO
                     for (int j = 0; j < copyInstead.Length; j++)
                     {
                         string copy = copyInstead[j];
-                        if (!string.IsNullOrEmpty(copy) && lower.Equals(copy))
+                        if (!string.IsNullOrEmpty(copy) && lower.Contains(copy))
                         {
                             exclude = true;
                             break;
@@ -93,7 +93,7 @@ namespace Nucleus.Gaming.Platform.Windows.IO
                     string exclusion = dirExclusions[j];
                     string fullPath = Path.Combine(root, exclusion).ToLower();
 
-                    if (!string.IsNullOrEmpty(exclusion) && fullPath.Equals(currentDir.FullName.ToLower()))
+                    if (!string.IsNullOrEmpty(exclusion) && fullPath.Contains(currentDir.FullName.ToLower()))
                     {
                         // special case, one of our subfolders is excluded
                         special = true;
@@ -103,14 +103,21 @@ namespace Nucleus.Gaming.Platform.Windows.IO
             }
 
 
-            if (!special)
-            {
+            //if (!special)
+            //{
                 // this folder has a child that cant be symlinked
                 //CmdUtil.MkLinkDirectory(currentDir.FullName, destination, out exitCode);
                 //Kernel32Interop.CreateSymbolicLink(destination, currentDir.FullName, Nucleus.Gaming.Platform.Windows.Interop.SymbolicLink.Directory);
                 if(symFolders)
                 {
-                    Kernel32Interop.CreateSymbolicLink(destination, currentDir.FullName, Nucleus.Gaming.Platform.Windows.Interop.SymbolicLink.Directory);
+                    if(!special)
+                    {
+                        Kernel32Interop.CreateSymbolicLink(destination, currentDir.FullName, Nucleus.Gaming.Platform.Windows.Interop.SymbolicLink.Directory);
+                    }
+                    else
+                    {
+                        Directory.CreateDirectory(destination);
+                    }
                 }
                 else
                 {
@@ -127,26 +134,26 @@ namespace Nucleus.Gaming.Platform.Windows.IO
                     DirectoryInfo child = children[i];
                     LinkDirectory(root, child, Path.Combine(destination, child.Name), out exitCode, dirExclusions, fileExclusions, fileCopyInstead, hardLink, symFolders);
                 }
-            }
-            else
-            {
-                // we symlink this directly
-                //CmdUtil.MkLinkDirectory(currentDir.FullName, destination, out exitCode);
+            //}
+            //else
+            //{
+            //    // we symlink this directly
+            //    //CmdUtil.MkLinkDirectory(currentDir.FullName, destination, out exitCode);
 
-                //Kernel32Interop.CreateSymbolicLink(destination, currentDir.FullName, Nucleus.Gaming.Platform.Windows.Interop.SymbolicLink.Directory);
-                //System.IO.DriveInfo di = new System.IO.DriveInfo(destination);
-                //System.IO.DirectoryInfo dirInfo = di.RootDirectory;
-                //Console.WriteLine("createsymboliclink: " + dirInfo.Attributes.ToString());
+            //    //Kernel32Interop.CreateSymbolicLink(destination, currentDir.FullName, Nucleus.Gaming.Platform.Windows.Interop.SymbolicLink.Directory);
+            //    //System.IO.DriveInfo di = new System.IO.DriveInfo(destination);
+            //    //System.IO.DirectoryInfo dirInfo = di.RootDirectory;
+            //    //Console.WriteLine("createsymboliclink: " + dirInfo.Attributes.ToString());
 
-                if (symFolders)
-                {
-                    Kernel32Interop.CreateSymbolicLink(destination, currentDir.FullName, Nucleus.Gaming.Platform.Windows.Interop.SymbolicLink.Directory);
-                }
-                else
-                {
-                    Directory.CreateDirectory(destination);
-                }
-            }
+            //    //if (symFolders)
+            //   // {
+            //       // Kernel32Interop.CreateSymbolicLink(destination, currentDir.FullName, Nucleus.Gaming.Platform.Windows.Interop.SymbolicLink.Directory);
+            //   // }
+            //   // else
+            //   // {
+            //        Directory.CreateDirectory(destination);
+            //   // }
+            //}
         }
     }
 }


### PR DESCRIPTION
- Reverted folder and file exclusion logic to the way it was done pre-0.9.8 (but still kept improvements made to them)
	- DirSymlinkExclusion will force hardcopy of the folder (if it is to be symlinked), FileSymlinkExclusion will completely ignore the file (no link/copy), FileSymlinkCopyInstead will continue to just create hardcopy of file instead of symlinking it
- Fixed xinput plus controller mappings when keyboard player was any player except last
- Prompt between instances can now be delayed if PauseBetweenStarts has a value